### PR TITLE
Homepage fixes

### DIFF
--- a/wp-content/themes/ga-health-news-2015/core/init.php
+++ b/wp-content/themes/ga-health-news-2015/core/init.php
@@ -4,27 +4,56 @@
 /* Define Constants */
 /*-----------------------------------------------------------------------------------*/
 
-	define('PLSH_PATH', get_template_directory() . '/');
-    define('PLSH_URL', get_template_directory_uri() . '/');
-    define('PLSH_CORE_PATH', get_template_directory() . '/core/');
-	define('PLSH_THEME_PATH', get_template_directory() . '/theme/');
-	define('PLSH_THEME_URL', get_template_directory_uri() . '/theme/');
-	define('PLSH_ADMIN_PANEL_PATH', get_template_directory() . '/core/panel/');
-    define('PLSH_ADMIN_PANEL_TEMPLATE_PATH', get_template_directory() . '/core/panel/templates/');
-    define('PLSH_ADMIN_ASSET_URL', get_template_directory_uri() . '/core/panel/assets/');
-	define('PLSH_LIB_PATH', get_template_directory() . '/core/lib/');
-	define('PLSH_IMG_URL', PLSH_THEME_URL . 'assets/images/');
-	define('PLSH_JS_URL', PLSH_THEME_URL . 'assets/js/');
-	define('PLSH_CSS_URL', PLSH_THEME_URL . 'assets/css/');
-    
+	// define('PLSH_PATH', get_template_directory() . '/');
+    // define('PLSH_URL', get_template_directory_uri() . '/');
+    if ( ! defined( 'PLSH_CORE_PATH' ) ) {
+		define('PLSH_CORE_PATH', get_template_directory() . '/core/');
+	}
+    if ( ! defined( 'PLSH_THEME_PATH' ) ) {
+		define('PLSH_THEME_PATH', get_template_directory() . '/theme/');
+	}
+	if ( ! defined( 'PLSH_THEME_URL' ) ) {
+		define('PLSH_THEME_URL', get_template_directory_uri() . '/theme/');
+	}
+	if ( ! defined( 'PLSH_ADMIN_PANEL_PATH' ) ) {
+		define('PLSH_ADMIN_PANEL_PATH', get_template_directory() . '/core/panel/');
+	}
+	if ( ! defined( 'PLSH_ADMIN_PANEL_TEMPLATE_PATH' ) ) {
+		define('PLSH_ADMIN_PANEL_TEMPLATE_PATH', get_template_directory() . '/core/panel/templates/');
+	}
+	if ( ! defined( 'PLSH_ADMIN_ASSET_URL' ) ) {
+		define('PLSH_ADMIN_ASSET_URL', get_template_directory_uri() . '/core/panel/assets/');
+	}
+
+	if ( ! defined( 'PLSH_LIB_PATH' ) ) {
+		define('PLSH_LIB_PATH', get_template_directory() . '/core/lib/');
+	}
+	if ( ! defined( 'PLSH_IMG_URL' ) ) {
+		define('PLSH_IMG_URL', PLSH_THEME_URL . 'assets/images/');
+	}
+	if ( ! defined( 'PLSH_JS_URL' ) ) {
+		define('PLSH_JS_URL', PLSH_THEME_URL . 'assets/js/');
+	}
+	if ( ! defined( 'PLSH_CSS_URL' ) ) {
+		define('PLSH_CSS_URL', PLSH_THEME_URL . 'assets/css/');
+	}
+
     $upload_dir = wp_upload_dir();
-    define('PLSH_UPLOAD_URL',  $upload_dir['baseurl'] . '/goliath/');
-    define('PLSH_UPLOAD_PATH',  $upload_dir['basedir'] . '/goliath/');
-    
-	define('PLSH_TEMPLATE_PATH', PLSH_THEME_PATH . 'templates/');
-    
-    define('PLSH_PLUGIN_PATH', PLSH_THEME_PATH . 'plugins/');
-    define('PLSH_WOOCOMMERCE_PATH', get_template_directory() . '/woocommerce/');
+	if ( ! defined( 'PLSH_UPLOAD_URL' ) ) {
+		define('PLSH_UPLOAD_URL',  $upload_dir['baseurl'] . '/goliath/');
+	}
+	if ( ! defined( 'PLSH_UPLOAD_PATH' ) ) {
+		define('PLSH_UPLOAD_PATH',  $upload_dir['basedir'] . '/goliath/');
+	}
+	if ( ! defined( 'PLSH_TEMPLATE_PATH' ) ) {
+		define('PLSH_TEMPLATE_PATH', PLSH_THEME_PATH . 'templates/');
+	}
+	if ( ! defined( 'PLSH_PLUGIN_PATH' ) ) {
+		define('PLSH_PLUGIN_PATH', PLSH_THEME_PATH . 'plugins/');
+	}
+	if ( ! defined( 'PLSH_WOOCOMMERCE_PATH' ) ) {
+		define('PLSH_WOOCOMMERCE_PATH', get_template_directory() . '/woocommerce/');
+	}
     define('PLSH_IS_CHILD', is_child_theme());
     
     if(PLSH_IS_CHILD)
@@ -60,10 +89,12 @@
 	$_SETTINGS = new Plsh_Settings();
 
 /*-----------------------------------------------------------------------------------*/
-/* Constants and Globals */
+/* A few more constants
 /*-----------------------------------------------------------------------------------*/
-	
+
+if ( ! defined( 'PLSH_THEME_DOMAIN' ) ) {
 	define('PLSH_THEME_DOMAIN', plsh_gs('theme_slug'));
+}
 
 /*-----------------------------------------------------------------------------------*/
 /* Add actions */

--- a/wp-content/themes/ga-health-news-2015/style.css
+++ b/wp-content/themes/ga-health-news-2015/style.css
@@ -38,7 +38,7 @@ div.post-block-1 div.slider .thumbs {
 
 @media (max-width:768px) {
 .slider-tabs div.post-item img {
-	max-width: auto !important;
+	max-width: 100%;
 	width: auto !important;
 }
 }

--- a/wp-content/themes/ga-health-news-2015/style.css
+++ b/wp-content/themes/ga-health-news-2015/style.css
@@ -1,10 +1,3 @@
-/* @override 
-	http://ghn.staging.wpengine.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.3.1
-	http://29psr521pjae1crn5q2h3bsx.wpengine.netdna-cdn.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.3.1
-	http://29psr521pjae1crn5q2h3bsx.wpengine.netdna-cdn.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.3.2
-	http://29psr521pjae1crn5q2h3bsx.wpengine.netdna-cdn.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.4.2
-*/
-
 /*
 Theme Name: GA Health News 2015
 Theme URI: http://test-georgia-health-news.pantheon.io/
@@ -15,8 +8,22 @@ Version: 0.0.0
 Template: goliath
 */
 
-/* Picobarn Edits */
+/* @override
+	http://ghn.staging.wpengine.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.3.1
+	http://29psr521pjae1crn5q2h3bsx.wpengine.netdna-cdn.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.3.1
+	http://29psr521pjae1crn5q2h3bsx.wpengine.netdna-cdn.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.3.2
+	http://29psr521pjae1crn5q2h3bsx.wpengine.netdna-cdn.com/wp-content/themes/ga-health-news-2015/style.css?ver=4.4.2
+*/
 
+
+/* Header */
+@media ( max-width: 970px ) and ( min-width: 768px ) {
+  .header .logo-image img {
+    max-width: 100%;
+  }
+}
+
+/* Picobarn edits */
 
 div.post-block-1 div.post-item:nth-child(1) {
 	display: none;
@@ -37,56 +44,47 @@ div.post-block-1 div.slider .thumbs {
 }
 
 @media (max-width:768px) {
-.slider-tabs div.post-item img {
-	max-width: 100%;
-	width: auto !important;
-}
+  .slider-tabs div.post-item img {
+    max-width: 100%;
+    width: auto !important;
+  }
 }
 
 @media (min-width:768px) {
+  div.post-block-1 div.items {
+    clear: none;
+    width: 50%;
+    margin-right: 0;
+    float: right;
+  }
 
-div.post-block-1 div.items {
-	clear: none;
-	width: 50%;
-	margin-right: 0;
-	float: right;
-}
+  div.post-block-1 .post-item div.title
+   {
+    width: 50% !important;
+  }
 
-div.post-block-1 .post-item div.title
- {
-	width: 50% !important;
-}
+  div.post-block-1 .slider div.title
+   {
+    width: 100% !important;
+  }
 
-div.post-block-1 .slider div.title
- {
-	width: 100% !important;
-}
+  div.post-block-1 .post-item {
+    width: 100%;
+    margin-right: 0;
+  }
 
-div.post-block-1 .post-item {
-	width: 100%;
-	margin-right: 0;
-}
+  div.post-block-1 div.slider {
+    margin-top: 1em;
+    height: 100px;
+  }
 
-div.post-block-1 div.slider {
-	margin-top: 1em;
-	height: 100px;
-}
-
-div.post-block-1 div.post-intro {
-	clear: left;
-}
-
-div.post-block-1 div.img {
-}
-
+  div.post-block-1 div.post-intro {
+    clear: left;
+  }
 }
 .sidebar-affix-wrap.affix {
 	position: relative !important;
 }
-
-.post-item-cycle-slide {
-}
-
 
 .iab-ad__wrapper {
 	display: none !important;

--- a/wp-content/themes/ga-health-news-2015/theme/templates/menu.php
+++ b/wp-content/themes/ga-health-news-2015/theme/templates/menu.php
@@ -1,0 +1,127 @@
+<!-- Menu responsive -->
+<div class="navbar-wrapper navbar-wrapper-responsive">
+    <div class="navbar navbar-default menu">
+        <div class="container">
+            <ul class="nav<?php if(plsh_gs('show_header_search') != 'on') { echo ' no-search'; } ?>">
+                <li class="active">
+                    
+                </li>
+                <li class="dropdown bars">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-bars"></i></a>
+                    
+                    <?php
+                        wp_nav_menu( array(
+                            'menu'              => 'primary-menu',
+                            'theme_location'    => 'primary-menu',
+                            'depth'             => 3,
+                            'container'         => 'div',
+                            'container_class'   => 'dropdown-menu full-width mobile-menu',
+                            'container_id'      => '',
+                            'menu_class'        => '',
+                            'menu_id'           => 'mobile-menu',
+                            'fallback_cb'       => 'wp_bootstrap_navwalker::fallback',
+                            //'walker'            => new wp_bootstrap_navwalker(),
+                            'no_constellation'  => true
+                            )
+                        );
+                    ?>
+                </li>
+                
+                <?php if(plsh_gs('show_menu_new_items') == 'on') { ?>
+                <li class="dropdown new-stories new">
+                    <a href="#" data-toggle="dropdown" class="dropdown-toggle" aria-haspopup="true"><s><?php echo plsh_gs('menu_new_items_count'); ?></s><span><?php _e('staff', 'goliath'); ?><br><?php _e('picks', 'goliath'); ?></span></a>
+                    <div class="dropdown-menu full-width">
+                        <?php 
+                            $catId = plsh_gs('menu_new_items_category');
+                            $catName = '';
+                            if(!empty($catId) && $catId != '')
+                            {
+                                $catObj = get_category($catId);
+                                $catName = $catObj->slug;
+                            }
+
+                            $params = array(
+                                'count' => plsh_gs('menu_new_items_count'),
+                                'max' => 2,
+                                'cat' => $catName,
+                                'tag' => ''
+                            );
+                            the_widget('GoliathDropdownPostList', $params);
+                        ?>
+                    </div>
+                </li>
+                <?php } ?>
+                
+                <?php if(plsh_gs('show_header_search') == 'on') { ?>
+                <li class="dropdown search">
+                    
+                    <form method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+                        <input type="text" name="s" class="form-control" placeholder="<?php _e( 'search here', 'goliath' ); ?>" />
+                    </form>
+                    
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-search"></i></a>
+                </li>
+                <?php } ?>
+                
+            </ul>
+        </div>
+    </div>
+</div>
+
+<!-- Menu -->
+<div class="navbar-wrapper">
+    <div class="navbar navbar-default menu">
+        <div class="container">
+            <?php
+                wp_nav_menu( array(
+                    'menu_id'           => 'menu-primary',
+                    'menu'              => 'primary-menu',
+                    'theme_location'    => 'primary-menu',
+                    'depth'             => 3,
+                    'container'         => 'div',
+                    'container_class'   => 'default-menu',
+                    'container_id'      => '',
+                    'menu_class'        => 'nav',
+                    'fallback_cb'       => 'wp_bootstrap_navwalker::fallback',
+                    'walker'            => new wp_bootstrap_navwalker()
+                    )
+                );
+            ?>
+            <?php if ( class_exists( 'Constellation' ) ) : ?>
+                <ul class="nav secondary-menu">
+                    <?php if(plsh_gs('show_header_search') == 'on') { ?>
+                    <li class="menu-item menu-item-type-custom menu-item-object-custom dropdown search">
+                        <?php get_search_form(); ?>
+                        <a href="#" data-toggle="dropdown" data-hover="dropdown" class="dropdown-toggle disabled" aria-haspopup="true"><i class="fa fa-search"></i></a>
+                    </li>
+                    <?php } ?>
+                    
+                    <li class="menu-item menu-item-type-custom menu-item-object-custom menu-spacer"></li>
+                    <?php if(plsh_gs('show_menu_new_items') == 'on') { ?>
+                    <li class="menu-item menu-item-type-custom menu-item-object-custom new-stories dropdown new">
+                        <a href="#" data-toggle="dropdown" data-hover="dropdown" class="dropdown-toggle disabled" aria-haspopup="true"><s><?php echo plsh_gs('menu_new_items_count'); ?></s><span><?php _e('staff', 'goliath'); ?><br><?php _e('picks', 'goliath'); ?></span></a>
+                        <div class="dropdown-menu full-width">
+                            <?php 
+                                $catId = plsh_gs('menu_new_items_category');
+                                $catName = '';
+                                if(!empty($catId) && $catId != '')
+                                {
+                                    $catObj = get_category($catId);
+                                    $catName = $catObj->slug;
+                                }
+                                
+                                $params = array(
+                                    'count' => plsh_gs('menu_new_items_count'),
+                                    'max' => 2,
+                                    'cat' => $catName,
+                                    'tag' => ''
+                                );
+                                the_widget('GoliathDropdownPostList', $params); ?>
+                        </div>
+                    </li>
+                    <?php } ?>
+                </ul>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>

--- a/wp-content/themes/ga-health-news-2015/theme/templates/menu.php
+++ b/wp-content/themes/ga-health-news-2015/theme/templates/menu.php
@@ -57,6 +57,7 @@
                     
                     <form method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
                         <input type="text" name="s" class="form-control" placeholder="<?php _e( 'search here', 'goliath' ); ?>" />
+						<button type="submit" title="<?php esc_attr_e( "Submit search", 'goliath' ) ?>" class="submit-button"><i class="fa fa-search"></i></button>
                     </form>
                     
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-search"></i></a>

--- a/wp-content/themes/goliath/core/init.php
+++ b/wp-content/themes/goliath/core/init.php
@@ -5,35 +5,74 @@
 /*-----------------------------------------------------------------------------------*/
 
 	define('PLSH_PATH', get_template_directory() . '/');
-    define('PLSH_URL', get_template_directory_uri() . '/');
-    define('PLSH_CORE_PATH', get_template_directory() . '/core/');
-	define('PLSH_THEME_PATH', get_template_directory() . '/theme/');
-	define('PLSH_THEME_URL', get_template_directory_uri() . '/theme/');
-	define('PLSH_ADMIN_PANEL_PATH', get_template_directory() . '/core/panel/');
-    define('PLSH_ADMIN_PANEL_TEMPLATE_PATH', get_template_directory() . '/core/panel/templates/');
-    define('PLSH_ADMIN_ASSET_URL', get_template_directory_uri() . '/core/panel/assets/');
-	define('PLSH_LIB_PATH', get_template_directory() . '/core/lib/');
-	define('PLSH_IMG_URL', PLSH_THEME_URL . 'assets/images/');
-	define('PLSH_JS_URL', PLSH_THEME_URL . 'assets/js/');
-	define('PLSH_CSS_URL', PLSH_THEME_URL . 'assets/css/');
-    
-    $upload_dir = wp_upload_dir();
-    define('PLSH_UPLOAD_URL',  $upload_dir['baseurl'] . '/goliath/');
-    define('PLSH_UPLOAD_PATH',  $upload_dir['basedir'] . '/goliath/');
-    
-	define('PLSH_TEMPLATE_PATH', PLSH_THEME_PATH . 'templates/');
-    define('PLSH_WIDGET_PATH', PLSH_THEME_PATH . 'widgets/');
-    define('PLSH_PLUGIN_PATH', PLSH_THEME_PATH . 'plugins/');
-    define('PLSH_WOOCOMMERCE_PATH', get_template_directory() . '/woocommerce/');
-    define('PLSH_IS_CHILD', is_child_theme());
-    
-    if(PLSH_IS_CHILD)
-    {
-        define('PLSH_CHILD_PATH', get_stylesheet_directory());
-        define('PLSH_CHILD_THEME_PATH', get_stylesheet_directory() . '/theme/');
-        define('PLSH_CHILD_TEMPLATE_PATH', PLSH_CHILD_THEME_PATH . 'templates/');
-    }
-	
+	define('PLSH_URL', get_template_directory_uri() . '/');
+	if ( ! defined( 'PLSH_CORE_PATH' ) ) {
+		define('PLSH_CORE_PATH', get_template_directory() . '/core/');
+	}
+	if ( ! defined( 'PLSH_THEME_PATH' ) ) {
+		define('PLSH_THEME_PATH', get_template_directory() . '/theme/');
+	}
+	if ( ! defined( 'PLSH_THEME_URL' ) ) {
+		define('PLSH_THEME_URL', get_template_directory_uri() . '/theme/');
+	}
+	if ( ! defined( 'PLSH_ADMIN_PANEL_PATH' ) ) {
+		define('PLSH_ADMIN_PANEL_PATH', get_template_directory() . '/core/panel/');
+	}
+	if ( ! defined( 'PLSH_ADMIN_PANEL_TEMPLATE_PATH' ) ) {
+		define('PLSH_ADMIN_PANEL_TEMPLATE_PATH', get_template_directory() . '/core/panel/templates/');
+	}
+	if ( ! defined( 'PLSH_ADMIN_ASSET_URL' ) ) {
+		define('PLSH_ADMIN_ASSET_URL', get_template_directory_uri() . '/core/panel/assets/');
+	}
+	if ( ! defined( 'PLSH_LIB_PATH' ) ) {
+		define('PLSH_LIB_PATH', get_template_directory() . '/core/lib/');
+	}
+	if ( ! defined( 'PLSH_IMG_URL' ) ) {
+		define('PLSH_IMG_URL', PLSH_THEME_URL . 'assets/images/');
+	}
+	if ( ! defined( 'PLSH_JS_URL' ) ) {
+		define('PLSH_JS_URL', PLSH_THEME_URL . 'assets/js/');
+	}
+	if ( ! defined( 'PLSH_CSS_URL' ) ) {
+		define('PLSH_CSS_URL', PLSH_THEME_URL . 'assets/css/');
+	}
+
+	$upload_dir = wp_upload_dir();
+
+	if ( ! defined( 'PLSH_UPLOAD_URL' ) ) {
+		define('PLSH_UPLOAD_URL',  $upload_dir['baseurl'] . '/goliath/');
+	}
+	if ( ! defined( 'PLSH_UPLOAD_PATH' ) ) {
+		define('PLSH_UPLOAD_PATH',  $upload_dir['basedir'] . '/goliath/');
+	}
+	if ( ! defined( 'PLSH_TEMPLATE_PATH' ) ) {
+		define('PLSH_TEMPLATE_PATH', PLSH_THEME_PATH . 'templates/');
+	}
+	if ( ! defined( 'PLSH_WIDGET_PATH' ) ) {
+		define('PLSH_WIDGET_PATH', PLSH_THEME_PATH . 'widgets/');
+	}
+	if ( ! defined( 'PLSH_PLUGIN_PATH' ) ) {
+		define('PLSH_PLUGIN_PATH', PLSH_THEME_PATH . 'plugins/');
+	}
+	if ( ! defined( 'PLSH_WOOCOMMERCE_PATH' ) ) {
+		define('PLSH_WOOCOMMERCE_PATH', get_template_directory() . '/woocommerce/');
+	}
+	if ( ! defined( 'PLSH_IS_CHILD' ) ) {
+		define('PLSH_IS_CHILD', is_child_theme());
+	}
+
+	if ( PLSH_IS_CHILD ) {
+		if ( ! defined( 'PLSH_CHILD_PATH' ) ) {
+			define('PLSH_CHILD_PATH', get_stylesheet_directory());
+		}
+		if ( ! defined( 'PLSH_CHILD_THEME_PATH' ) ) {
+			define('PLSH_CHILD_THEME_PATH', get_stylesheet_directory() . '/theme/');
+		}
+		if ( ! defined( 'PLSH_CHILD_TEMPLATE_PATH' ) ) {
+			define('PLSH_CHILD_TEMPLATE_PATH', PLSH_CHILD_THEME_PATH . 'templates/');
+		}
+	}
+
 /*-----------------------------------------------------------------------------------*/
 /* Load the required Framework Files */
 /*-----------------------------------------------------------------------------------*/
@@ -59,8 +98,11 @@
 /*-----------------------------------------------------------------------------------*/
 /* Constants and Globals */
 /*-----------------------------------------------------------------------------------*/
-	
+
+if ( ! defined( 'PLSH_THEME_DOMAIN' ) ) {
 	define('PLSH_THEME_DOMAIN', plsh_gs('theme_slug'));
+}
+
 
 /*-----------------------------------------------------------------------------------*/
 /* Add actions */

--- a/wp-content/themes/goliath/theme/assets/css/main.css
+++ b/wp-content/themes/goliath/theme/assets/css/main.css
@@ -1885,6 +1885,7 @@ textarea.form-control {
 
 .homepage-content {
 	padding: 0;
+  z-index: 100; /* https://github.com/INN/umbrella-ghn/issues/7#issuecomment-610037492 */
 }
 
 .main-content-column-1 {

--- a/wp-content/themes/goliath/theme/assets/css/phone.css
+++ b/wp-content/themes/goliath/theme/assets/css/phone.css
@@ -204,16 +204,24 @@ body {
 	z-index: 100000;
 }
 
-.navbar-wrapper-responsive .menu .nav .search:after {
+.navbar-wrapper-responsive .menu .nav .search i.fa-search::before {
 	font-family: FontAwesome;
 	content: "\f002";
-	color: #ff5732;
+	color: inherit;
 	font-size: 15px;
+}
+.navbar-wrapper-responsive .menu .nav .search .submit-button {
 	position: absolute;
 	display: block;
-	top: 77px;
-	right: 32px;
+	top: 70px;
+	right: 20px;
 	z-index: 100000;
+  border-radius: 0;
+  width: 34px;
+  height: 34px;
+  background-color: white;
+  border: 1px solid black;
+  color: #ff5732;
 }
 
 /* Revslider Slider */

--- a/wp-content/themes/goliath/theme/assets/css/tablet.css
+++ b/wp-content/themes/goliath/theme/assets/css/tablet.css
@@ -103,6 +103,9 @@
 	display: block;
 	float: right;
 }
+.navbar-wrapper-responsive .menu .nav .search .submit-button {
+  display: none;
+}
 
 .menu ul.nav li.new-stories {
 	display: block;

--- a/wp-content/themes/goliath/theme/theme-functions.php
+++ b/wp-content/themes/goliath/theme/theme-functions.php
@@ -118,23 +118,31 @@ if(!function_exists('plsh_setup'))
 
 if(!function_exists('plsh_add_stylesheets'))
 {
-    function plsh_add_stylesheets() 
-    {
-        wp_enqueue_style( 'plsh-bootstrap', PLSH_CSS_URL . 'bootstrap.min.css' );
-        wp_enqueue_style( 'plsh-font-awesome', PLSH_CSS_URL . 'font-awesome.min.css' );
-        
-        wp_enqueue_style( 'plsh-main', PLSH_CSS_URL . 'main.css' );
-        wp_enqueue_style( 'plsh-tablet', PLSH_CSS_URL . 'tablet.css' );
-        wp_enqueue_style( 'plsh-phone', PLSH_CSS_URL . 'phone.css' );
-        wp_enqueue_style( 'plsh-woocommerce', PLSH_CSS_URL . 'woocommerce.css' );
-        wp_enqueue_style( 'plsh-bbpress', PLSH_CSS_URL . 'bbpress.css' );
-        wp_enqueue_style( 'plsh-wordpress_style', PLSH_CSS_URL . 'wordpress.css' );
-        wp_enqueue_style( 'plsh-sharrre', PLSH_CSS_URL . 'sharrre.css' );
-        wp_enqueue_style( 'plsh-style', get_bloginfo( 'stylesheet_url' ) );   
+	function plsh_add_stylesheets() 
+	{
+		wp_enqueue_style(
+			'plsh-bootstrap',
+			PLSH_CSS_URL . 'bootstrap.min.css'
+		);
+		wp_enqueue_style( 'plsh-font-awesome', PLSH_CSS_URL . 'font-awesome.min.css' );
+		
+		wp_enqueue_style( 'plsh-main', PLSH_CSS_URL . 'main.css' );
+		wp_enqueue_style( 'plsh-tablet', PLSH_CSS_URL . 'tablet.css' );
+		wp_enqueue_style( 'plsh-phone', PLSH_CSS_URL . 'phone.css' );
+		wp_enqueue_style( 'plsh-woocommerce', PLSH_CSS_URL . 'woocommerce.css' );
+		wp_enqueue_style( 'plsh-bbpress', PLSH_CSS_URL . 'bbpress.css' );
+		wp_enqueue_style( 'plsh-wordpress_style', PLSH_CSS_URL . 'wordpress.css' );
+		wp_enqueue_style( 'plsh-sharrre', PLSH_CSS_URL . 'sharrre.css' );
+		wp_enqueue_style(
+			'plsh-style',
+			get_bloginfo( 'stylesheet_url' ),
+			array(),
+			filemtime( get_stylesheet_directory() . '/' . basename( get_stylesheet_uri() ) )
+		);
 		wp_enqueue_style( 'plsh-google-fonts', plsh_google_fonts_url(), array(), null );
-    }
+	}
 }
-    
+
 if(!function_exists('plsh_print_scripts_in_footer'))
 {
     function plsh_print_scripts_in_footer( &$scripts) 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Changes how constants are defined to reduce the amount of PHP notices that get dumped to the log
- Fixes the header image being wider than its container at specific viewport widths
- Fixes the black image overlay appearing underneath following elements on the page, by adjusting the z-index of an ancestor element
- Cachebusts one of the stylesheets
- Replaces fake search button in mobile nav at certain viewport widths with an actual search button

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #7

## Testing/Questions

Features that this PR affects:

- homepage , particularly the search in the nav

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] Does the search work in other screen sizes?
- [x] Should we cachebust other stylesheets
- [x] Are we worried about the ridiculous number of stylesheets on this site and do we want to investigate a plugin that might concatenate and/or tree-shake them?

Steps to test this PR:

1. Check it out, then view it at many screen sizes
2. Play with the search in the menu
3. Play with the hoverable elements on the page