### PR TITLE
Fix image aspect ratio in homepage sliders on mobile, debounce a scroll event

### DIFF
--- a/wp-content/themes/ga-health-news-2015/style.css
+++ b/wp-content/themes/ga-health-news-2015/style.css
@@ -45,6 +45,7 @@ div.post-block-1 div.slider .thumbs {
 
 @media (max-width:768px) {
   .slider-tabs div.post-item img {
+    height: auto;
     max-width: 100%;
     width: auto !important;
   }

--- a/wp-content/themes/goliath/theme/theme-functions.php
+++ b/wp-content/themes/goliath/theme/theme-functions.php
@@ -173,8 +173,15 @@ if(!function_exists('plsh_add_scripts'))
         wp_enqueue_script( 'plsh-hoverintent', PLSH_JS_URL . 'vendor/jquery.hoverintent.min.js', array( 'jquery' ), false, true);
         wp_enqueue_script( 'plsh-sharrre', PLSH_JS_URL . 'vendor/jquery.sharrre.min.js', array( 'jquery' ), false, true);
         wp_enqueue_script( 'plsh-particles', PLSH_JS_URL . 'vendor/jquery.particleground.js', array( 'jquery' ), false, true);
-        wp_enqueue_script( 'plsh-theme', PLSH_JS_URL . 'theme.js', array( 'jquery', 'plsh-sharrre' ), false, true);
-        
+
+		wp_enqueue_script(
+			'plsh-theme',
+			PLSH_JS_URL . 'theme.js',
+			array( 'jquery', 'plsh-sharrre' ),
+			filemtime( get_template_directory() . '/theme/assets/js/theme.js' ),
+			true
+		);
+
         $ajax_object = array();
         $ajax_object['ajaxurl'] = admin_url( 'admin-ajax.php' );
         $ajax_object['readmore'] = __('Read more', 'goliath');


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Changes the image aspect ratio on the homepage sliders on mobile so they aren't stretched vertically
- Debounces the thing that checked whether to show/hide the button to smooth-scroll the browser to the top of the page, because that was firing every scroll tick and never showing the button as a result. Now it should show up sometimes, with much less thrashing.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #3 

## Testing/Questions

Features that this PR affects:

- On mobile, the homepage top section should change from the first image to the second image:
![Screen Shot 2020-04-15 at 15 35 06](https://user-images.githubusercontent.com/1754187/79380676-be879080-7f2e-11ea-9f54-e5639950b1e7.png)
![Screen Shot 2020-04-15 at 15 35 06](https://user-images.githubusercontent.com/1754187/79380689-c2b3ae00-7f2e-11ea-8372-ac7a0160e765.png)
- on browsers more than ~1300px wide, in the lower right, a button should appear.



<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] do we want to fiddle with the scroll behavior of the button?

Steps to test this PR:

1. check out the branch.
